### PR TITLE
feat: multipart snapshot download

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -203,7 +203,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -27,6 +27,8 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	fs.StringVar(&opt.Generation, "generation", "", "generation name")
 	fs.Var((*indexVar)(&opt.Index), "index", "wal index")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
+	fs.IntVar(&opt.MultipartConcurrency, "multipart-concurrency", opt.MultipartConcurrency, "multipart-concurrency")
+	fs.Int64Var(&opt.MultipartSize, "multipart-size", opt.MultipartSize, "multipart-size")
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
@@ -197,6 +199,19 @@ Arguments:
 	    Determines the number of WAL files downloaded in parallel.
 	    Defaults to `+strconv.Itoa(litestream.DefaultRestoreParallelism)+`.
 
+	-multipart-concurrency NUM
+	    Determines the number of parts to download in parallel per file.
+	    This requires buffering up to multipart-concurrency * multipart-size
+	    bytes in memory. Note that this is only implemented for s3 snapshots;
+	    it is ignored by other implementations.
+	    Defaults to 0 (multipart download disabled).
+
+	-multipart-size BYTES
+	    Downloads the snapshot with -parallelism concurrent requests
+	    in parts of the specified size. This requires buffering up to
+	    parallelism * multipart-size bytes in memory.  Note that this is only
+	    implemented for s3 snapshots; it is ignored by other implementations.
+	    Defaults to 0 (multipart download disabled).
 
 Examples:
 

--- a/db.go
+++ b/db.go
@@ -1589,6 +1589,17 @@ type RestoreOptions struct {
 
 	// Specifies how many WAL files are downloaded in parallel during restore.
 	Parallelism int
+
+	// Specifies how many parts to download in parallel per file.
+	// If 0, multipart download is disabled and the file is downloaded
+	// sequentially in a single request. May be ignored if not supported
+	// by the implementation.
+	MultipartConcurrency int
+
+	// Specifies the size of the parts to download. If 0, multipart download
+	// is disabled and the file is downloaded sequentially in a single request.
+	// May be ignored if not supported by the implementation.
+	MultipartSize int64
 }
 
 // NewRestoreOptions returns a new instance of RestoreOptions with defaults.

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -236,7 +236,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
 // Returns os.ErrNotExist if no matching index is found.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	filename, err := c.SnapshotPath(generation, index)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine snapshot path: %w", err)

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -174,7 +174,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -44,7 +44,7 @@ func (c *ReplicaClient) DeleteSnapshot(ctx context.Context, generation string, i
 	return c.DeleteSnapshotFunc(ctx, generation, index)
 }
 
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	return c.SnapshotReaderFunc(ctx, generation, index)
 }
 

--- a/replica.go
+++ b/replica.go
@@ -1111,10 +1111,14 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Initialize starting position.
 	pos := Pos{Generation: opt.Generation, Index: minWALIndex}
 	tmpPath := opt.OutputPath + ".tmp"
+	readerOpts := &ReaderOptions{
+		MultipartConcurrency: opt.MultipartConcurrency,
+		MultipartSize:        opt.MultipartSize,
+	}
 
 	// Copy snapshot to output path.
 	r.Logger().Info("restoring snapshot", "generation", opt.Generation, "index", minWALIndex, "path", tmpPath)
-	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath); err != nil {
+	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath, readerOpts); err != nil {
 		return fmt.Errorf("cannot restore snapshot: %w", err)
 	}
 
@@ -1335,7 +1339,7 @@ func (r *Replica) walSegmentMap(ctx context.Context, generation string, minIndex
 }
 
 // restoreSnapshot copies a snapshot from the replica to a file.
-func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string) error {
+func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string, opt *ReaderOptions) error {
 	// Determine the user/group & mode based on the DB, if available.
 	var fileInfo, dirInfo os.FileInfo
 	if db := r.DB(); db != nil {
@@ -1352,7 +1356,7 @@ func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index 
 	}
 	defer f.Close()
 
-	rd, err := r.Client.SnapshotReader(ctx, generation, index)
+	rd, err := r.Client.SnapshotReader(ctx, generation, index, opt)
 	if err != nil {
 		return err
 	}

--- a/replica_client.go
+++ b/replica_client.go
@@ -5,6 +5,11 @@ import (
 	"io"
 )
 
+type ReaderOptions struct {
+	MultipartConcurrency int
+	MultipartSize        int64
+}
+
 // ReplicaClient represents client to connect to a Replica.
 type ReplicaClient interface {
 	// Returns the type of client.
@@ -29,7 +34,9 @@ type ReplicaClient interface {
 	// Returns a reader that contains LZ4 compressed snapshot data for a
 	// given index within a generation. Returns an os.ErrNotFound error if
 	// the snapshot does not exist.
-	SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error)
+	//
+	// The ReaderOptions may be nil or ignored by the implementation.
+	SnapshotReader(ctx context.Context, generation string, index int, opt *ReaderOptions) (io.ReadCloser, error)
 
 	// Returns an iterator of all WAL segments within a generation on the replica. Order is undefined.
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -190,7 +190,7 @@ func TestReplicaClient_WriteSnapshot(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if r, err := c.SnapshotReader(context.Background(), "b16ddcf5c697540f", 1000); err != nil {
+		if r, err := c.SnapshotReader(context.Background(), "b16ddcf5c697540f", 1000, nil); err != nil {
 			t.Fatal(err)
 		} else if buf, err := io.ReadAll(r); err != nil {
 			t.Fatal(err)
@@ -217,7 +217,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 10)
+		r, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 10, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -230,10 +230,34 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 		}
 	})
 
+	RunWithReplicaClient(t, "Multipart", func(t *testing.T, c litestream.ReplicaClient) {
+		t.Parallel()
+
+		content := strings.Repeat(`abc123`, 10000)
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(content)); err != nil {
+			t.Fatal(err)
+		}
+
+		r, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 10, &litestream.ReaderOptions{
+			MultipartConcurrency: 13,
+			MultipartSize:        123,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+
+		if buf, err := io.ReadAll(r); err != nil {
+			t.Fatal(err)
+		} else if got, want := string(buf), content; got != want {
+			t.Fatalf("ReadAll=%v, want %v", got, want)
+		}
+	})
+
 	RunWithReplicaClient(t, "ErrNotFound", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 1); !os.IsNotExist(err) {
+		if _, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 1, nil); !os.IsNotExist(err) {
 			t.Fatalf("expected not exist, got %#v", err)
 		}
 	})
@@ -241,7 +265,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 	RunWithReplicaClient(t, "ErrNoGeneration", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.SnapshotReader(context.Background(), "", 1); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
+		if _, err := c.SnapshotReader(context.Background(), "", 1, nil); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/s3/multi_part.go
+++ b/s3/multi_part.go
@@ -1,0 +1,171 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/benbjohnson/litestream/internal"
+)
+
+func Download(ctx context.Context, sd *s3manager.Downloader, input *s3.GetObjectInput) io.ReadCloser {
+	r, w := io.Pipe()
+	m := NewChunkManager(w, sd.PartSize, sd.Concurrency)
+
+	go func() {
+		if _, err := sd.DownloadWithContext(ctx, m, input); err != nil {
+			if isNotExists(err) {
+				err = os.ErrNotExist
+			}
+			m.w.CloseWithError(err)
+		} else {
+			m.DownloadDone()
+		}
+	}()
+
+	go m.PipeCompletedChunks()
+
+	return r
+}
+
+type chunk struct {
+	start   int64
+	written int64
+	buf     *bytes.Buffer
+}
+
+type chunkManager struct {
+	w        *io.PipeWriter
+	partSize int64
+
+	free         []*chunk   // free pool of buffers
+	nextInLine   *sync.Cond // next in line to start downloading
+	downloadHead int64
+	downloading  sync.Map // maps startPos -> chunks receiving data
+
+	flushHead int64
+	done      sync.Map // maps startPos -> chunks ready to be flushed
+
+	full chan *chunk // full chunks
+}
+
+// Exposed for testing
+func NewChunkManager(w *io.PipeWriter, partSize int64, concurrency int) *chunkManager {
+	m := &chunkManager{
+		w:          w,
+		partSize:   partSize,
+		free:       make([]*chunk, 0, concurrency),
+		nextInLine: sync.NewCond(&sync.Mutex{}),
+		full:       make(chan *chunk),
+	}
+	for i := 0; i < concurrency; i++ {
+		m.free = append(m.free, &chunk{})
+	}
+	return m
+}
+
+func (m *chunkManager) WriteAt(p []byte, pos int64) (n int, err error) {
+	chunk := m.getChunk(pos)
+	n, err = chunk.buf.Write(p)
+	if err == nil {
+		chunk.written += int64(n)
+		if chunk.written >= m.partSize {
+			m.full <- chunk
+		}
+	}
+	return
+}
+
+func (m *chunkManager) getChunk(pos int64) *chunk {
+	chunkStart := pos - (pos % m.partSize)
+	if c, exists := m.downloading.Load(chunkStart); exists {
+		return c.(*chunk)
+	}
+
+	newChunk := m.getFree(chunkStart)
+	newChunk.start = chunkStart
+	newChunk.written = 0
+
+	if newChunk.buf == nil {
+		// Pre-allocate space for the chunk, both for speed and to avoid
+		// over-allocating with on-demand Buffer growth.
+		newChunk.buf = new(bytes.Buffer)
+		newChunk.buf.Grow(int(m.partSize))
+	} else {
+		newChunk.buf.Reset()
+	}
+
+	m.downloading.Store(chunkStart, newChunk)
+	return newChunk
+}
+
+func (m *chunkManager) getFree(chunkStart int64) *chunk {
+	// To prevent head-of-line blocking, concurrent requesters take from
+	// the free pool in head-of-line order.
+	m.nextInLine.L.Lock()
+	defer m.nextInLine.L.Unlock()
+
+	for m.downloadHead != chunkStart || len(m.free) == 0 {
+		m.nextInLine.Wait()
+	}
+	num := len(m.free)
+	chunk := m.free[num-1]
+	m.free = m.free[:num-1]
+	m.downloadHead += m.partSize
+
+	m.nextInLine.Broadcast()
+	return chunk
+}
+
+func (m *chunkManager) setFree(c *chunk) {
+	m.nextInLine.L.Lock()
+	defer m.nextInLine.L.Unlock()
+
+	m.free = append(m.free, c)
+	m.nextInLine.Broadcast()
+}
+
+// Exposed for testing
+func (m *chunkManager) PipeCompletedChunks() {
+	for chunk := range m.full {
+		// Move the chunk from m.pending to m.done
+		m.downloading.Delete(chunk.start)
+		m.done.Store(chunk.start, chunk)
+
+		// Flush the head of the line
+		m.flush(&m.done)
+	}
+
+	// Once m.full is closed, there are no more writers.
+	// The final chunk at the flushHead will be in m.pending
+	// if it did not reach the full partSize.
+	m.flush(&m.downloading)
+	m.w.Close()
+}
+
+// Exposed for testing
+func (m *chunkManager) DownloadDone() {
+	close(m.full)
+}
+
+func (m *chunkManager) flush(chunks *sync.Map) {
+	for c, exists := chunks.Load(m.flushHead); exists; c, exists = chunks.Load(m.flushHead) {
+		chunk := c.(*chunk)
+		io.Copy(m.w, chunk.buf)
+		chunks.Delete(m.flushHead)
+		num := chunk.written
+
+		m.setFree(chunk)
+
+		m.flushHead += m.partSize
+
+		// Each chunk corresponds to an underlying GET in the s3 client.
+		internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "GET").Inc()
+		internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "GET").Add(float64(aws.Int64Value(&num)))
+	}
+}

--- a/s3/multi_part_test.go
+++ b/s3/multi_part_test.go
@@ -1,0 +1,70 @@
+package s3_test
+
+import (
+	"bytes"
+	crypto "crypto/rand"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/benbjohnson/litestream/s3"
+)
+
+func TestMultiPartDownload(t *testing.T) {
+	const numBytes = 1234 * 1023 // Non-round size to ensure a partial part at the end
+	const partSize = 1000
+
+	for _, c := range []int{1, 2, 23} {
+		t.Run(fmt.Sprintf("concurrency=%d", c), func(t *testing.T) {
+			testMultiPartDownload(t, numBytes, partSize, c)
+		})
+	}
+}
+
+func testMultiPartDownload(t *testing.T, numBytes int64, partSize int64, concurrency int) {
+	randomBytes := make([]byte, numBytes)
+	if _, err := crypto.Read(randomBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	r, w := io.Pipe()
+	m := s3.NewChunkManager(w, partSize, concurrency)
+	go m.PipeCompletedChunks()
+
+	var head atomic.Int64
+	nextHead := func() int64 {
+		return head.Add(partSize) - partSize
+	}
+
+	// Simulates the s3.Downloader by running `concurrency` routines that
+	// take `partSize`` slices of the randomBytes from the head and call
+	// m.WriteAt() to randomly send the slices to the chunk manager.
+	var requests sync.WaitGroup
+	requests.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			for start := nextHead(); start < numBytes; start = nextHead() {
+				for end := min(numBytes, start+partSize); start < end; {
+					len := rand.Int63n(end-start) + 1
+					m.WriteAt(randomBytes[start:start+len], start)
+					start += len
+				}
+			}
+			requests.Done()
+		}()
+	}
+
+	go func() {
+		requests.Wait()
+		m.DownloadDone()
+	}()
+
+	if result, err := io.ReadAll(r); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(randomBytes, result) {
+		t.Fatalf("downloaded bytes not equal")
+	}
+}

--- a/s3/multi_part_test.go
+++ b/s3/multi_part_test.go
@@ -31,8 +31,8 @@ func testMultiPartDownload(t *testing.T, numBytes int64, partSize int64, concurr
 	}
 
 	r, w := io.Pipe()
-	m := s3.NewChunkManager(w, partSize, concurrency)
-	go m.PipeCompletedChunks()
+	m := s3.NewPartManager(w, partSize, concurrency)
+	go m.PipeCompletedParts()
 
 	var head atomic.Int64
 	nextHead := func() int64 {
@@ -41,7 +41,7 @@ func testMultiPartDownload(t *testing.T, numBytes int64, partSize int64, concurr
 
 	// Simulates the s3.Downloader by running `concurrency` routines that
 	// take `partSize`` slices of the randomBytes from the head and call
-	// m.WriteAt() to randomly send the slices to the chunk manager.
+	// m.WriteAt() to randomly send the slices to the part manager.
 	var requests sync.WaitGroup
 	requests.Add(concurrency)
 	for i := 0; i < concurrency; i++ {

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -275,7 +275,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (_ io.ReadCloser, err error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (_ io.ReadCloser, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)


### PR DESCRIPTION
Adds two options to `litestream restore`:
* `-multipart-concurrency`
* `-multipart-size`

to leverage the multi-part download s3 API for snapshot downloads.

This results in using `multipart-concurrency` * `multipart-size` bytes of memory as a buffer between the network download and lz4 decompression, speeding up a 100GB restore from ~35 minutes to ~5 minutes.