### PR TITLE
Revert "Switch to S3 HEAD to find bucket location (#580)"

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -140,12 +140,12 @@ func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (st
 
 	// Fetch bucket location, if possible. Must be bucket owner.
 	// This call can return a nil location which means it's in us-east-1.
-	if out, err := s3.New(sess).HeadBucketWithContext(ctx, &s3.HeadBucketInput{
+	if out, err := s3.New(sess).GetBucketLocation(&s3.GetBucketLocationInput{
 		Bucket: aws.String(bucket),
 	}); err != nil {
 		return "", err
-	} else if out.BucketRegion != nil {
-		return *out.BucketRegion, nil
+	} else if out.LocationConstraint != nil {
+		return *out.LocationConstraint, nil
 	}
 	return DefaultRegion, nil
 }


### PR DESCRIPTION
This reverts commit 5be467a478adcffc5b3999b9503cc676c2bf09f1 as it breaks litestream outside of us-east-1 as reported in https://github.com/benbjohnson/litestream/issues/621