### PR TITLE
chore: handle virtual columns in watermark tables

### DIFF
--- a/db.go
+++ b/db.go
@@ -512,8 +512,8 @@ func (db *DB) init() (err error) {
 		if db.watermarkPos, err = lite.GetDBPos(db.db, db.WatermarkTable, db.WatermarkColumn, 0); err != nil {
 			return err
 		}
-		db.Logger.Info(fmt.Sprintf(`tracking watermark "%s"."%s" on page=%d cid=%d`,
-			db.WatermarkTable, db.WatermarkColumn, db.watermarkPos.Page(), db.watermarkPos.CID()))
+		db.Logger.Info(fmt.Sprintf(`tracking watermark "%s"."%s" on page=%d col=%d`,
+			db.WatermarkTable, db.WatermarkColumn, db.watermarkPos.Page(), db.watermarkPos.Col()))
 	}
 
 	// Ensure meta directory structure exists.

--- a/lite/page.go
+++ b/lite/page.go
@@ -11,23 +11,23 @@ import (
 // The position of a value within a page.
 type PagePos interface {
 	Row() int
-	CID() int
+	Col() int
 }
 
 // The position of a value within the database.
 type DBPos struct {
 	page uint32
 	row  int
-	cid  int
+	col  int
 }
 
-func NewDBPos(page uint32, row int, cid int) *DBPos {
-	return &DBPos{page: page, row: row, cid: cid}
+func NewDBPos(page uint32, row int, col int) *DBPos {
+	return &DBPos{page: page, row: row, col: col}
 }
 
 func (pos *DBPos) Page() uint32 { return pos.page }
 func (pos *DBPos) Row() int     { return pos.row }
-func (pos *DBPos) CID() int     { return pos.cid }
+func (pos *DBPos) Col() int     { return pos.col }
 
 // Gets the position of the value specified by the given `table`, `column`
 // and `row` (in ROWID order). This assumes that the table fits within a
@@ -89,7 +89,7 @@ func ReadTextValueFromLeafPage(page []byte, pagePos PagePos) (string, error) {
 	// Record format: https://sqlite.org/fileformat.html#record_format
 	header := bytes.NewReader(payload[pos:])
 	// The header consists of an initial (varint) header size, followed
-	// by varint sizes of each column value in cid order.
+	// by varint sizes of each stored column value.
 	recordHeaderLen, err := binary.ReadUvarint(header)
 	if err != nil {
 		return "", err
@@ -102,7 +102,7 @@ func ReadTextValueFromLeafPage(page []byte, pagePos PagePos) (string, error) {
 			return "", nil
 		}
 		valueLen := lengthOf(serialType)
-		if i == pagePos.CID() {
+		if i == pagePos.Col() {
 			return string(payload[pos : pos+valueLen]), nil
 		}
 		pos += valueLen


### PR DESCRIPTION
Fix the logic in `GetDBPos` to use `PRAGMA table_xinfo` to take into account hidden and generated columns. The column position is computed as the `cid` minus the number of preceding virtual generated columns.

Reference discussion: https://github.com/rocicorp/litestream/pull/3#discussion_r2072460572