### PR TITLE
fix: adjust the multipart upload size based on the total upload size

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -168,7 +168,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd to the object storage.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}
@@ -258,7 +258,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -183,7 +183,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	filename, err := c.SnapshotPath(generation, index)
 	if err != nil {
 		return info, fmt.Errorf("cannot determine snapshot path: %w", err)
@@ -298,7 +298,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	filename, err := c.WALSegmentPath(pos.Generation, pos.Index, pos.Offset)
 	if err != nil {
 		return info, fmt.Errorf("cannot determine wal segment path: %w", err)

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -139,7 +139,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd to the object storage.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}
@@ -229,7 +229,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -36,7 +36,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 	return c.SnapshotsFunc(ctx, generation)
 }
 
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader) (litestream.SnapshotInfo, error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader, uncompressedSize int64) (litestream.SnapshotInfo, error) {
 	return c.WriteSnapshotFunc(ctx, generation, index, r)
 }
 
@@ -52,7 +52,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 	return c.WALSegmentsFunc(ctx, generation)
 }
 
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, r io.Reader) (litestream.WALSegmentInfo, error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, r io.Reader, uncompressedSize int64) (litestream.WALSegmentInfo, error) {
 	return c.WriteWALSegmentFunc(ctx, pos, r)
 }
 

--- a/replica_client.go
+++ b/replica_client.go
@@ -25,8 +25,11 @@ type ReplicaClient interface {
 	Snapshots(ctx context.Context, generation string) (SnapshotIterator, error)
 
 	// Writes LZ4 compressed snapshot data to the replica at a given index
-	// within a generation. Returns metadata for the snapshot.
-	WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader) (SnapshotInfo, error)
+	// within a generation. The uncompressedSize is supplied to allow
+	// implementations to perform appropriate optimizations.
+	//
+	// Returns metadata for the snapshot.
+	WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader, uncompressedSize int64) (SnapshotInfo, error)
 
 	// Deletes a snapshot with the given generation & index.
 	DeleteSnapshot(ctx context.Context, generation string, index int) error
@@ -42,8 +45,11 @@ type ReplicaClient interface {
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)
 
 	// Writes an LZ4 compressed WAL segment at a given position.
+	// The uncompressedSize is supplied to allow implementations to perform
+	// appropriate optimizations.
+	//
 	// Returns metadata for the written segment.
-	WriteWALSegment(ctx context.Context, pos Pos, r io.Reader) (WALSegmentInfo, error)
+	WriteWALSegment(ctx context.Context, pos Pos, r io.Reader, uncompressedSize int64) (WALSegmentInfo, error)
 
 	// Deletes one or more WAL segments at the given positions.
 	DeleteWALSegments(ctx context.Context, a []Pos) error

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -67,11 +67,11 @@ func TestReplicaClient_Generations(t *testing.T) {
 		t.Parallel()
 
 		// Write snapshots.
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 0, strings.NewReader(`bar`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 0, strings.NewReader(`bar`), 3); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "155fe292f8333c72", 0, strings.NewReader(`baz`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "155fe292f8333c72", 0, strings.NewReader(`baz`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -103,11 +103,11 @@ func TestReplicaClient_Snapshots(t *testing.T) {
 		t.Parallel()
 
 		// Write snapshots.
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 1, strings.NewReader(``)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 1, strings.NewReader(``), 0); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 5, strings.NewReader(`x`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 5, strings.NewReader(`x`), 1); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 10, strings.NewReader(`xyz`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 10, strings.NewReader(`xyz`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -186,7 +186,7 @@ func TestReplicaClient_WriteSnapshot(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 1000, strings.NewReader(`foobar`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 1000, strings.NewReader(`foobar`), 6); err != nil {
 			t.Fatal(err)
 		}
 
@@ -203,7 +203,7 @@ func TestReplicaClient_WriteSnapshot(t *testing.T) {
 
 	RunWithReplicaClient(t, "ErrNoGeneration", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
-		if _, err := c.WriteSnapshot(context.Background(), "", 0, nil); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
+		if _, err := c.WriteSnapshot(context.Background(), "", 0, nil, 0); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -213,7 +213,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -234,7 +234,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 		t.Parallel()
 
 		content := strings.Repeat(`abc123`, 10000)
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(content)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(content), int64(len(content))); err != nil {
 			t.Fatal(err)
 		}
 
@@ -275,14 +275,14 @@ func TestReplicaClient_WALs(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 1, Offset: 0}, strings.NewReader(``)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 1, Offset: 0}, strings.NewReader(``), 0); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 0}, strings.NewReader(`12345`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 0}, strings.NewReader(`12345`), 5); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 5}, strings.NewReader(`67`)); err != nil {
+		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 5}, strings.NewReader(`67`), 2); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 3, Offset: 0}, strings.NewReader(`xyz`)); err != nil {
+		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 3, Offset: 0}, strings.NewReader(`xyz`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -363,7 +363,7 @@ func TestReplicaClient_WALs(t *testing.T) {
 	RunWithReplicaClient(t, "NoWALs", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -395,7 +395,7 @@ func TestReplicaClient_WriteWALSegment(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1000, Offset: 2000}, strings.NewReader(`foobar`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1000, Offset: 2000}, strings.NewReader(`foobar`), 6); err != nil {
 			t.Fatal(err)
 		}
 
@@ -412,7 +412,7 @@ func TestReplicaClient_WriteWALSegment(t *testing.T) {
 
 	RunWithReplicaClient(t, "ErrNoGeneration", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "", Index: 0, Offset: 0}, nil); err == nil || err.Error() != `cannot determine wal segment path: generation required` {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "", Index: 0, Offset: 0}, nil, 0); err == nil || err.Error() != `cannot determine wal segment path: generation required` {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -422,7 +422,7 @@ func TestReplicaClient_WALReader(t *testing.T) {
 
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 10, Offset: 5}, strings.NewReader(`foobar`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 10, Offset: 5}, strings.NewReader(`foobar`), 6); err != nil {
 			t.Fatal(err)
 		}
 
@@ -452,9 +452,9 @@ func TestReplicaClient_DeleteWALSegments(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1, Offset: 2}, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1, Offset: 2}, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 3, Offset: 4}, strings.NewReader(`bar`)); err != nil {
+		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 3, Offset: 4}, strings.NewReader(`bar`), 3); err != nil {
 			t.Fatal(err)
 		}
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -242,7 +242,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}
@@ -346,7 +346,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -37,9 +38,8 @@ var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing snapshots & WAL segments to disk.
 type ReplicaClient struct {
-	mu       sync.Mutex
-	s3       *s3.S3 // s3 service
-	uploader *s3manager.Uploader
+	mu sync.Mutex
+	s3 *s3.S3 // s3 service
 
 	// AWS authentication keys.
 	AccessKeyID     string
@@ -102,7 +102,6 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		return fmt.Errorf("cannot create aws session: %w", err)
 	}
 	c.s3 = s3.New(sess)
-	c.uploader = s3manager.NewUploader(sess)
 	return nil
 }
 
@@ -241,6 +240,35 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 	return newSnapshotIterator(ctx, c, generation), nil
 }
 
+// TODO: Allow concurrency and part size to be optimized, similarly
+// to the multipart download API.
+func (c *ReplicaClient) newUploader(uncompressedSize int64) *s3manager.Uploader {
+	return s3manager.NewUploaderWithClient(c.s3, func(d *s3manager.Uploader) {
+		// The Uploader attempts to perform an initSize() optimization to configure the
+		// upload part size based on the total upload size. However, this is only possible
+		// if the io.Reader that it is given implements io.Seeker:
+		//
+		// https://github.com/aws/aws-sdk-go/blob/163aada692ed32951f979aacf452ded4c03b8a7c/service/s3/s3manager/upload.go#L440
+		//
+		// For litestream, the Reader is a PipeReader through which the uploaded bytes run
+		// through LZ4 compression, so seeking (and thus, the optimization) is not possible.
+		// Instead, emulate the Uploader logic based on the uncompressedSize of the
+		// data being uploaded. This will be an overestimate and result in larger
+		// than necessary part sizes, which is fine.
+
+		// Adapted from:
+		// https://github.com/aws/aws-sdk-go/blob/163aada692ed32951f979aacf452ded4c03b8a7c/service/s3/s3manager/upload.go#L451
+
+		// Try to adjust partSize if it is too small and account for
+		// integer division truncation.
+		if uncompressedSize/d.PartSize >= int64(d.MaxUploadParts) {
+			// Add one to the part size to account for remainders
+			// during the size calculation. e.g odd number of bytes.
+			d.PartSize = (uncompressedSize / int64(d.MaxUploadParts)) + 1
+		}
+	})
+}
+
 // WriteSnapshot writes LZ4 compressed data from rd into a file on disk.
 func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	if err := c.Init(ctx); err != nil {
@@ -254,7 +282,9 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 	startTime := time.Now()
 
 	rc := internal.NewReadCounter(rd)
-	if _, err := c.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+	uploader := c.newUploader(uncompressedSize)
+	slog.Debug(fmt.Sprintf("uploading snapshot with part size %d", uploader.PartSize))
+	if _, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		Bucket: aws.String(c.Bucket),
 		Key:    aws.String(key),
 		Body:   rc,
@@ -358,7 +388,8 @@ func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos,
 	startTime := time.Now()
 
 	rc := internal.NewReadCounter(rd)
-	if _, err := c.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+	uploader := c.newUploader(uncompressedSize)
+	if _, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		Bucket: aws.String(c.Bucket),
 		Key:    aws.String(key),
 		Body:   rc,

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -230,7 +230,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (_ lit
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd to the object storage.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)
@@ -362,7 +362,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (_ l
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)


### PR DESCRIPTION
Attempting to upload (to s3) a snapshot for which the LZ4 compressed size is more than 50,000 MB results in the following error from AWS:

```
"error":"MultipartUpload: upload multipart failed\n\tupload id: ...
caused by: 
  TotalPartsExceeded: exceeded total allowed configured MaxUploadParts (10000). 
  Adjust PartSize to fit in this limit"
```

The s3.Uploader [automatically adjusts the multipart upload size](https://github.com/aws/aws-sdk-go/blob/163aada692ed32951f979aacf452ded4c03b8a7c/service/s3/s3manager/upload.go#L440)  _if_ the `io.Reader` that it is provided implements the `io.Seeker` interface (e.g. a normal file). 

However, litestream passes a PipeReader for the purpose of LZ4 compression, which disables this automatic adjustment logic since the total size cannot be determined.

To fix this, pass the uncompressed number of bytes to be uploaded, and perform the adjustment that the Uploader would have done. The result is an over-estimate since it is based on uncompressed bytes, but using more memory during the upload is better than underestimating and failing with an error.