### PR TITLE
feat: allow configuration of multipart (s3) uploads

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -203,7 +203,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -356,6 +356,20 @@ type ReplicaConfig struct {
 	Endpoint        string `yaml:"endpoint"`
 	ForcePathStyle  *bool  `yaml:"force-path-style"`
 	SkipVerify      bool   `yaml:"skip-verify"`
+	// Determines the number of parts to upload or download in parallel per file.
+	// This requires buffering up to multipart-concurrency * multipart-size
+	// bytes in memory. Note that this is only implemented for s3, and when
+	// restoring, only for snapshots (and not for wal segments).
+	// It is ignored by other implementations.
+	//
+	// If unspecified, uses the AWS sdk default value of 5.
+	// Set to 0 to disable multipart downloads.
+	MultipartConcurrency *int `yaml:"multipart-concurrency"`
+	// Determines the size of each part to upload or download.
+	// See documentation for multipart-concurrency.
+	//
+	// If unspecified, uses the AWS sdk default of 5MB.
+	MultipartSize *int64 `yaml:"multipart-size"`
 
 	// ABS settings
 	AccountName string `yaml:"account-name"`
@@ -535,6 +549,12 @@ func newS3ReplicaClientFromConfig(c *ReplicaConfig, r *litestream.Replica) (_ *s
 	client.Endpoint = endpoint
 	client.ForcePathStyle = forcePathStyle
 	client.SkipVerify = skipVerify
+	if c.MultipartConcurrency != nil {
+		*client.MultipartConcurrency = *c.MultipartConcurrency
+	}
+	if c.MultipartSize != nil {
+		*client.MultipartSize = *c.MultipartSize
+	}
 	return client, nil
 }
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -549,12 +549,8 @@ func newS3ReplicaClientFromConfig(c *ReplicaConfig, r *litestream.Replica) (_ *s
 	client.Endpoint = endpoint
 	client.ForcePathStyle = forcePathStyle
 	client.SkipVerify = skipVerify
-	if c.MultipartConcurrency != nil {
-		*client.MultipartConcurrency = *c.MultipartConcurrency
-	}
-	if c.MultipartSize != nil {
-		*client.MultipartSize = *c.MultipartSize
-	}
+	client.MultipartConcurrency = c.MultipartConcurrency
+	client.MultipartSize = c.MultipartSize
 	return client, nil
 }
 

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -27,8 +27,6 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	fs.StringVar(&opt.Generation, "generation", "", "generation name")
 	fs.Var((*indexVar)(&opt.Index), "index", "wal index")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
-	fs.IntVar(&opt.MultipartConcurrency, "multipart-concurrency", opt.MultipartConcurrency, "multipart-concurrency")
-	fs.Int64Var(&opt.MultipartSize, "multipart-size", opt.MultipartSize, "multipart-size")
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
@@ -198,20 +196,6 @@ Arguments:
 	-parallelism NUM
 	    Determines the number of WAL files downloaded in parallel.
 	    Defaults to `+strconv.Itoa(litestream.DefaultRestoreParallelism)+`.
-
-	-multipart-concurrency NUM
-	    Determines the number of parts to download in parallel per file.
-	    This requires buffering up to multipart-concurrency * multipart-size
-	    bytes in memory. Note that this is only implemented for s3 snapshots;
-	    it is ignored by other implementations.
-	    Defaults to 0 (multipart download disabled).
-
-	-multipart-size BYTES
-	    Downloads the snapshot with -parallelism concurrent requests
-	    in parts of the specified size. This requires buffering up to
-	    parallelism * multipart-size bytes in memory.  Note that this is only
-	    implemented for s3 snapshots; it is ignored by other implementations.
-	    Defaults to 0 (multipart download disabled).
 
 Examples:
 

--- a/db.go
+++ b/db.go
@@ -1591,17 +1591,6 @@ type RestoreOptions struct {
 
 	// Specifies how many WAL files are downloaded in parallel during restore.
 	Parallelism int
-
-	// Specifies how many parts to download in parallel per file.
-	// If 0, multipart download is disabled and the file is downloaded
-	// sequentially in a single request. May be ignored if not supported
-	// by the implementation.
-	MultipartConcurrency int
-
-	// Specifies the size of the parts to download. If 0, multipart download
-	// is disabled and the file is downloaded sequentially in a single request.
-	// May be ignored if not supported by the implementation.
-	MultipartSize int64
 }
 
 // NewRestoreOptions returns a new instance of RestoreOptions with defaults.

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -236,7 +236,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
 // Returns os.ErrNotExist if no matching index is found.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	filename, err := c.SnapshotPath(generation, index)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine snapshot path: %w", err)

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -174,7 +174,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -44,7 +44,7 @@ func (c *ReplicaClient) DeleteSnapshot(ctx context.Context, generation string, i
 	return c.DeleteSnapshotFunc(ctx, generation, index)
 }
 
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	return c.SnapshotReaderFunc(ctx, generation, index)
 }
 

--- a/replica.go
+++ b/replica.go
@@ -1115,14 +1115,10 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Initialize starting position.
 	pos := Pos{Generation: opt.Generation, Index: minWALIndex}
 	tmpPath := opt.OutputPath + ".tmp"
-	readerOpts := &ReaderOptions{
-		MultipartConcurrency: opt.MultipartConcurrency,
-		MultipartSize:        opt.MultipartSize,
-	}
 
 	// Copy snapshot to output path.
 	r.Logger().Info("restoring snapshot", "generation", opt.Generation, "index", minWALIndex, "path", tmpPath)
-	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath, readerOpts); err != nil {
+	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath); err != nil {
 		return fmt.Errorf("cannot restore snapshot: %w", err)
 	}
 
@@ -1343,7 +1339,7 @@ func (r *Replica) walSegmentMap(ctx context.Context, generation string, minIndex
 }
 
 // restoreSnapshot copies a snapshot from the replica to a file.
-func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string, opt *ReaderOptions) error {
+func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string) error {
 	// Determine the user/group & mode based on the DB, if available.
 	var fileInfo, dirInfo os.FileInfo
 	if db := r.DB(); db != nil {
@@ -1360,7 +1356,7 @@ func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index 
 	}
 	defer f.Close()
 
-	rd, err := r.Client.SnapshotReader(ctx, generation, index, opt)
+	rd, err := r.Client.SnapshotReader(ctx, generation, index)
 	if err != nil {
 		return err
 	}

--- a/replica_client.go
+++ b/replica_client.go
@@ -5,11 +5,6 @@ import (
 	"io"
 )
 
-type ReaderOptions struct {
-	MultipartConcurrency int
-	MultipartSize        int64
-}
-
 // ReplicaClient represents client to connect to a Replica.
 type ReplicaClient interface {
 	// Returns the type of client.
@@ -39,7 +34,7 @@ type ReplicaClient interface {
 	// the snapshot does not exist.
 	//
 	// The ReaderOptions may be nil or ignored by the implementation.
-	SnapshotReader(ctx context.Context, generation string, index int, opt *ReaderOptions) (io.ReadCloser, error)
+	SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error)
 
 	// Returns an iterator of all WAL segments within a generation on the replica. Order is undefined.
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -53,9 +53,9 @@ type ReplicaClient struct {
 	ForcePathStyle bool
 	SkipVerify     bool
 
-	// S3 object download options
-	MultipartDownloadConcurrency int
-	MultipartDownloadSize        int
+	// S3 object multipart options
+	MultipartConcurrency *int
+	MultipartSize        *int64
 }
 
 // NewReplicaClient returns a new instance of ReplicaClient.
@@ -306,7 +306,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}
@@ -321,24 +321,29 @@ func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, i
 		Key:    aws.String(key),
 	}
 
-	if opt != nil && opt.MultipartConcurrency > 0 && opt.MultipartSize > 0 {
-		downloader := s3manager.NewDownloaderWithClient(c.s3, func(d *s3manager.Downloader) {
-			d.Concurrency = opt.MultipartConcurrency
-			d.PartSize = opt.MultipartSize
-		})
-		return Download(ctx, downloader, input), nil
+	if c.MultipartConcurrency != nil && *c.MultipartConcurrency == 0 {
+		// Multipart downloads are explicitly disabled by setting concurrency to 0.
+		out, err := c.s3.GetObjectWithContext(ctx, input)
+		if isNotExists(err) {
+			return nil, os.ErrNotExist
+		} else if err != nil {
+			return nil, err
+		}
+		internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "GET").Inc()
+		internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "GET").Add(float64(aws.Int64Value(out.ContentLength)))
+
+		return out.Body, nil
 	}
 
-	out, err := c.s3.GetObjectWithContext(ctx, input)
-	if isNotExists(err) {
-		return nil, os.ErrNotExist
-	} else if err != nil {
-		return nil, err
-	}
-	internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "GET").Inc()
-	internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "GET").Add(float64(aws.Int64Value(out.ContentLength)))
-
-	return out.Body, nil
+	downloader := s3manager.NewDownloaderWithClient(c.s3, func(d *s3manager.Downloader) {
+		if c.MultipartConcurrency != nil {
+			d.Concurrency = *c.MultipartConcurrency
+		}
+		if c.MultipartSize != nil {
+			d.PartSize = *c.MultipartSize
+		}
+	})
+	return Download(ctx, downloader, input), nil
 }
 
 // DeleteSnapshot deletes a snapshot with the given generation & index.

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -275,7 +275,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (_ io.ReadCloser, err error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (_ io.ReadCloser, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)


### PR DESCRIPTION
* changes the previously flag-based multipart download (restore) options to be driven by the config
* uses the values, when present, to configure the existing multipart uploads

This makes the upload and download logic symmetric in terms of API and memory usage.