### PR TITLE
fix: fix multipart S3 downloads when a part is retried

### DIFF
--- a/s3/multi_part.go
+++ b/s3/multi_part.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"os"
@@ -36,7 +35,7 @@ func Download(ctx context.Context, sd *s3manager.Downloader, input *s3.GetObject
 type part struct {
 	start   int64
 	written int64
-	buf     *bytes.Buffer
+	buf     []byte
 }
 
 // The partManager manages the multi-part download done by the s3.Downloader,
@@ -115,14 +114,25 @@ func (m *partManager) getFree(chunkStart int64) *part {
 // by the s3.Downloader.
 func (m *partManager) WriteAt(p []byte, pos int64) (n int, err error) {
 	part := m.getDownloading(pos)
-	n, err = part.buf.Write(p)
-	if err == nil {
-		part.written += int64(n)
+	off := pos - part.start
+	end := off + int64(len(p))
+	if off < 0 || end > int64(len(part.buf)) {
+		return 0, io.ErrShortWrite
+	}
+
+	n = copy(part.buf[int(off):int(end)], p)
+	if n != len(p) {
+		return n, io.ErrShortWrite
+	}
+
+	if end > part.written {
+		part.written = end
 		if part.written >= m.partSize {
 			m.full <- part
 		}
 	}
-	return
+
+	return n, nil
 }
 
 func (m *partManager) getDownloading(pos int64) *part {
@@ -136,12 +146,7 @@ func (m *partManager) getDownloading(pos int64) *part {
 	part.written = 0
 
 	if part.buf == nil {
-		// Pre-allocate space for the part, both for speed and to avoid
-		// over-allocating with on-demand Buffer growth.
-		part.buf = new(bytes.Buffer)
-		part.buf.Grow(int(m.partSize))
-	} else {
-		part.buf.Reset()
+		part.buf = make([]byte, int(m.partSize))
 	}
 
 	m.downloading.Store(start, part)
@@ -174,7 +179,7 @@ func (m *partManager) DownloadDone() {
 func (m *partManager) flush(parts *sync.Map) {
 	for p, exists := parts.Load(m.flushHead); exists; p, exists = parts.Load(m.flushHead) {
 		p := p.(*part)
-		io.Copy(m.w, p.buf)
+		m.w.Write(p.buf[:int(p.written)])
 
 		num := p.written
 		m.setFree(p)

--- a/s3/multi_part.go
+++ b/s3/multi_part.go
@@ -33,9 +33,9 @@ func Download(ctx context.Context, sd *s3manager.Downloader, input *s3.GetObject
 }
 
 type part struct {
-	start   int64
-	written int64
-	buf     []byte
+	start      int64
+	maxWritten int64
+	buf        []byte
 }
 
 // The partManager manages the multi-part download done by the s3.Downloader,
@@ -125,9 +125,9 @@ func (m *partManager) WriteAt(p []byte, pos int64) (n int, err error) {
 		return n, io.ErrShortWrite
 	}
 
-	if end > part.written {
-		part.written = end
-		if part.written >= m.partSize {
+	if end > part.maxWritten {
+		part.maxWritten = end
+		if part.maxWritten >= m.partSize {
 			m.full <- part
 		}
 	}
@@ -143,7 +143,7 @@ func (m *partManager) getDownloading(pos int64) *part {
 
 	part := m.getFree(start)
 	part.start = start
-	part.written = 0
+	part.maxWritten = 0
 
 	if part.buf == nil {
 		part.buf = make([]byte, int(m.partSize))
@@ -179,9 +179,9 @@ func (m *partManager) DownloadDone() {
 func (m *partManager) flush(parts *sync.Map) {
 	for p, exists := parts.Load(m.flushHead); exists; p, exists = parts.Load(m.flushHead) {
 		p := p.(*part)
-		m.w.Write(p.buf[:int(p.written)])
+		m.w.Write(p.buf[:int(p.maxWritten)])
 
-		num := p.written
+		num := p.maxWritten
 		m.setFree(p)
 
 		parts.Delete(m.flushHead)

--- a/s3/multi_part_test.go
+++ b/s3/multi_part_test.go
@@ -68,3 +68,42 @@ func testMultiPartDownload(t *testing.T, numBytes int64, partSize int64, concurr
 		t.Fatalf("downloaded bytes not equal")
 	}
 }
+
+func TestMultiPartDownloadRetryRewritesPart(t *testing.T) {
+	const partSize int64 = 8
+	payload := []byte("abcdefghijklmnop")
+
+	r, w := io.Pipe()
+	m := s3.NewPartManager(w, partSize, 1)
+	go m.PipeCompletedParts()
+
+	type readResult struct {
+		buf []byte
+		err error
+	}
+	resultCh := make(chan readResult, 1)
+	go func() {
+		buf, err := io.ReadAll(r)
+		resultCh <- readResult{buf: buf, err: err}
+	}()
+
+	if _, err := m.WriteAt(payload[:3], 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.WriteAt(payload[:int(partSize)], 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.WriteAt(payload[int(partSize):], partSize); err != nil {
+		t.Fatal(err)
+	}
+
+	m.DownloadDone()
+
+	result := <-resultCh
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if !bytes.Equal(payload, result.buf) {
+		t.Fatalf("unexpected payload: %q", result.buf)
+	}
+}


### PR DESCRIPTION
This change fixes a bug in multipart S3 downloads when AWS retries a failed part.

When the AWS downloader retries a part, it can start writing that part from the beginning again. Our old buffering logic kept appending bytes, which could duplicate earlier data and corrupt the final output.

## Details

The S3 multipart downloader can retry an individual part if the response body read is interrupted mid-stream. In that case, the downloader restarts the same ranged GET and writes the bytes again at the original offset.

Our multipart download buffering was appending incoming bytes within a part instead of respecting the write offset relative to that part. When a retried write arrived for the same part start, previously buffered bytes were duplicated and the output stream became corrupted.

This matters because corrupted multipart snapshot bytes may not fail immediately, but can surface later during restore as LZ4 decode failures.

This would then result in a full resync, as seen multiple times with Productlane: 
1. https://www.notion.so/replicache/March-13-2026-Productlane-Rollout-Resync-Outage-3233bed8954580d1b7fff845e90e1a6a
2. https://rocicorp.slack.com/archives/C09UGFS9M71/p1774952287363299

## Testing

Try running `go test ./s3 -run TestMultiPartDownloadRetryRewritesPart` before/after the fix.