### PR TITLE
Zero

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -203,7 +203,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -203,7 +203,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -168,7 +168,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd to the object storage.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}
@@ -258,7 +258,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -256,6 +256,15 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 
 	logOptions := slog.HandlerOptions{
 		Level: slog.LevelInfo,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			switch a.Key {
+			case slog.MessageKey:
+				a.Key = "message"
+			case slog.TimeKey:
+				a.Key = "timestamp"
+			}
+			return a
+		},
 	}
 
 	switch strings.ToUpper(config.Logging.Level) {
@@ -274,6 +283,10 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 	case "text", "":
 		logHandler = slog.NewTextHandler(logOutput, &logOptions)
 	}
+
+	logHandler = logHandler.WithAttrs([]slog.Attr{
+		{Key: "worker", Value: slog.StringValue("litestream")},
+	})
 
 	// Set global default logger.
 	slog.SetDefault(slog.New(logHandler))

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -303,6 +303,8 @@ type DBConfig struct {
 	BusyTimeout        *time.Duration `yaml:"busy-timeout"`
 	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
 	MaxCheckpointPageN *int           `yaml:"max-checkpoint-page-count"`
+	WatermarkTable     *string        `yaml:"watermark-table"`
+	WatermarkColumn    *string        `yaml:"watermark-column"`
 
 	Replicas []*ReplicaConfig `yaml:"replicas"`
 }
@@ -335,6 +337,10 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	}
 	if dbc.MaxCheckpointPageN != nil {
 		db.MaxCheckpointPageN = *dbc.MaxCheckpointPageN
+	}
+	if dbc.WatermarkTable != nil && dbc.WatermarkColumn != nil {
+		db.WatermarkTable = *dbc.WatermarkTable
+		db.WatermarkColumn = *dbc.WatermarkColumn
 	}
 
 	// Instantiate and attach replicas.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -356,6 +356,20 @@ type ReplicaConfig struct {
 	Endpoint        string `yaml:"endpoint"`
 	ForcePathStyle  *bool  `yaml:"force-path-style"`
 	SkipVerify      bool   `yaml:"skip-verify"`
+	// Determines the number of parts to upload or download in parallel per file.
+	// This requires buffering up to multipart-concurrency * multipart-size
+	// bytes in memory. Note that this is only implemented for s3, and when
+	// restoring, only for snapshots (and not for wal segments).
+	// It is ignored by other implementations.
+	//
+	// If unspecified, uses the AWS sdk default value of 5.
+	// Set to 0 to disable multipart downloads.
+	MultipartConcurrency *int `yaml:"multipart-concurrency"`
+	// Determines the size of each part to upload or download.
+	// See documentation for multipart-concurrency.
+	//
+	// If unspecified, uses the AWS sdk default of 5MB.
+	MultipartSize *int64 `yaml:"multipart-size"`
 
 	// ABS settings
 	AccountName string `yaml:"account-name"`
@@ -535,6 +549,8 @@ func newS3ReplicaClientFromConfig(c *ReplicaConfig, r *litestream.Replica) (_ *s
 	client.Endpoint = endpoint
 	client.ForcePathStyle = forcePathStyle
 	client.SkipVerify = skipVerify
+	client.MultipartConcurrency = c.MultipartConcurrency
+	client.MultipartSize = c.MultipartSize
 	return client, nil
 }
 

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -27,6 +27,8 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	fs.StringVar(&opt.Generation, "generation", "", "generation name")
 	fs.Var((*indexVar)(&opt.Index), "index", "wal index")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
+	fs.IntVar(&opt.MultipartConcurrency, "multipart-concurrency", opt.MultipartConcurrency, "multipart-concurrency")
+	fs.Int64Var(&opt.MultipartSize, "multipart-size", opt.MultipartSize, "multipart-size")
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
@@ -197,6 +199,19 @@ Arguments:
 	    Determines the number of WAL files downloaded in parallel.
 	    Defaults to `+strconv.Itoa(litestream.DefaultRestoreParallelism)+`.
 
+	-multipart-concurrency NUM
+	    Determines the number of parts to download in parallel per file.
+	    This requires buffering up to multipart-concurrency * multipart-size
+	    bytes in memory. Note that this is only implemented for s3 snapshots;
+	    it is ignored by other implementations.
+	    Defaults to 0 (multipart download disabled).
+
+	-multipart-size BYTES
+	    Downloads the snapshot with -parallelism concurrent requests
+	    in parts of the specified size. This requires buffering up to
+	    parallelism * multipart-size bytes in memory.  Note that this is only
+	    implemented for s3 snapshots; it is ignored by other implementations.
+	    Defaults to 0 (multipart download disabled).
 
 Examples:
 

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -27,8 +27,6 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	fs.StringVar(&opt.Generation, "generation", "", "generation name")
 	fs.Var((*indexVar)(&opt.Index), "index", "wal index")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
-	fs.IntVar(&opt.MultipartConcurrency, "multipart-concurrency", opt.MultipartConcurrency, "multipart-concurrency")
-	fs.Int64Var(&opt.MultipartSize, "multipart-size", opt.MultipartSize, "multipart-size")
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
@@ -198,20 +196,6 @@ Arguments:
 	-parallelism NUM
 	    Determines the number of WAL files downloaded in parallel.
 	    Defaults to `+strconv.Itoa(litestream.DefaultRestoreParallelism)+`.
-
-	-multipart-concurrency NUM
-	    Determines the number of parts to download in parallel per file.
-	    This requires buffering up to multipart-concurrency * multipart-size
-	    bytes in memory. Note that this is only implemented for s3 snapshots;
-	    it is ignored by other implementations.
-	    Defaults to 0 (multipart download disabled).
-
-	-multipart-size BYTES
-	    Downloads the snapshot with -parallelism concurrent requests
-	    in parts of the specified size. This requires buffering up to
-	    parallelism * multipart-size bytes in memory.  Note that this is only
-	    implemented for s3 snapshots; it is ignored by other implementations.
-	    Defaults to 0 (multipart download disabled).
 
 Examples:
 

--- a/db.go
+++ b/db.go
@@ -1591,6 +1591,17 @@ type RestoreOptions struct {
 
 	// Specifies how many WAL files are downloaded in parallel during restore.
 	Parallelism int
+
+	// Specifies how many parts to download in parallel per file.
+	// If 0, multipart download is disabled and the file is downloaded
+	// sequentially in a single request. May be ignored if not supported
+	// by the implementation.
+	MultipartConcurrency int
+
+	// Specifies the size of the parts to download. If 0, multipart download
+	// is disabled and the file is downloaded sequentially in a single request.
+	// May be ignored if not supported by the implementation.
+	MultipartSize int64
 }
 
 // NewRestoreOptions returns a new instance of RestoreOptions with defaults.

--- a/db.go
+++ b/db.go
@@ -512,8 +512,8 @@ func (db *DB) init() (err error) {
 		if db.watermarkPos, err = lite.GetDBPos(db.db, db.WatermarkTable, db.WatermarkColumn, 0); err != nil {
 			return err
 		}
-		db.Logger.Info(fmt.Sprintf(`tracking watermark "%s"."%s" on page=%d cid=%d`,
-			db.WatermarkTable, db.WatermarkColumn, db.watermarkPos.Page(), db.watermarkPos.CID()))
+		db.Logger.Info(fmt.Sprintf(`tracking watermark "%s"."%s" on page=%d col=%d`,
+			db.WatermarkTable, db.WatermarkColumn, db.watermarkPos.Page(), db.watermarkPos.Col()))
 	}
 
 	// Ensure meta directory structure exists.

--- a/db.go
+++ b/db.go
@@ -1591,17 +1591,6 @@ type RestoreOptions struct {
 
 	// Specifies how many WAL files are downloaded in parallel during restore.
 	Parallelism int
-
-	// Specifies how many parts to download in parallel per file.
-	// If 0, multipart download is disabled and the file is downloaded
-	// sequentially in a single request. May be ignored if not supported
-	// by the implementation.
-	MultipartConcurrency int
-
-	// Specifies the size of the parts to download. If 0, multipart download
-	// is disabled and the file is downloaded sequentially in a single request.
-	// May be ignored if not supported by the implementation.
-	MultipartSize int64
 }
 
 // NewRestoreOptions returns a new instance of RestoreOptions with defaults.

--- a/db.go
+++ b/db.go
@@ -1487,7 +1487,22 @@ func (db *DB) monitor() {
 
 		// Sync the database to the shadow WAL.
 		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
-			db.Logger.Error("sync error", "error", err)
+			// Passive checkpoints immediately fail if a write happens to be in
+			// progress on the database, even if a busy_timeout is set:
+			// https://sqlite.org/pragma.html#pragma_wal_checkpoint
+			//
+			// For databases with a high rate of writes, this results in a high
+			// amount of "error" messages for a condition that is not really an
+			// error, as passive checkpoints are intended to be best effort.
+			//
+			// To better reflect the nature of the condition in the least invasive
+			// way possible, the condition is still propagated as an error in the
+			// implementation, but logged at a lower severity here.
+			if strings.Contains(err.Error(), "checkpoint: mode=PASSIVE err=database is locked") {
+				db.Logger.Info("skipped periodic checkpoint because database was busy", "error", err)
+			} else {
+				db.Logger.Error("sync error", "error", err)
+			}
 		}
 	}
 }

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -183,7 +183,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	filename, err := c.SnapshotPath(generation, index)
 	if err != nil {
 		return info, fmt.Errorf("cannot determine snapshot path: %w", err)
@@ -298,7 +298,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	filename, err := c.WALSegmentPath(pos.Generation, pos.Index, pos.Offset)
 	if err != nil {
 		return info, fmt.Errorf("cannot determine wal segment path: %w", err)

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -236,7 +236,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
 // Returns os.ErrNotExist if no matching index is found.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	filename, err := c.SnapshotPath(generation, index)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine snapshot path: %w", err)

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -236,7 +236,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
 // Returns os.ErrNotExist if no matching index is found.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	filename, err := c.SnapshotPath(generation, index)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine snapshot path: %w", err)

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -139,7 +139,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd to the object storage.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}
@@ -229,7 +229,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	if err := c.Init(ctx); err != nil {
 		return info, err
 	}

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -174,7 +174,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -174,7 +174,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}

--- a/lite/page.go
+++ b/lite/page.go
@@ -1,0 +1,124 @@
+package lite
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"os"
+)
+
+// The position of a value within a page.
+type PagePos interface {
+	Row() int
+	CID() int
+}
+
+// The position of a value within the database.
+type DBPos struct {
+	page uint32
+	row  int
+	cid  int
+}
+
+func NewDBPos(page uint32, row int, cid int) *DBPos {
+	return &DBPos{page: page, row: row, cid: cid}
+}
+
+func (pos *DBPos) Page() uint32 { return pos.page }
+func (pos *DBPos) Row() int     { return pos.row }
+func (pos *DBPos) CID() int     { return pos.cid }
+
+// Gets the position of the value specified by the given `table`, `column`
+// and `row` (in ROWID order). This assumes that the table fits within a
+// single database page, i.e. that the `rootpage` of the table in the
+// `sqlite_schema` table points directly to the b-tree leaf page.
+func GetDBPos(db *sql.DB, table string, column string, row int) (*DBPos, error) {
+	var pageNo uint32
+	var cid int
+	if err := db.QueryRow(`SELECT cid FROM pragma_table_info(?) where name = ?`, table, column).
+		Scan(&cid); err != nil {
+		return nil, fmt.Errorf(`lookup db pos ("%s"."%s") cid: %w`, table, column, err)
+	}
+	if err := db.QueryRow(`SELECT rootpage FROM sqlite_schema WHERE name = ?`, table).
+		Scan(&pageNo); err != nil {
+		return nil, fmt.Errorf("lookup %s rootpage: %w", table, err)
+	}
+	return NewDBPos(pageNo, row, cid), nil
+}
+
+// Reads the page for the given `pageNo` from the main db file.
+func ReadPage(db *os.File, pageNo uint32, pageSize int) ([]byte, error) {
+	page := make([]byte, pageSize)
+	if _, err := db.ReadAt(page, int64((pageNo-1)*uint32(pageSize))); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+// Reads the value with the given `pagePos` from the `page`.
+func ReadTextValueFromLeafPage(page []byte, pagePos PagePos) (string, error) {
+	// B-tree page header format: https://sqlite.org/fileformat.html#cell_payload
+	if page[0] != 0xD { // Table b-tree leaf page
+		return "", fmt.Errorf("unexpected page type %x", page[0])
+	}
+	row := pagePos.Row()
+	numRows := int(binary.BigEndian.Uint16(page[3:5]))
+	if numRows <= row {
+		return "", fmt.Errorf("insufficient number of rows %d for row %d", numRows, row)
+	}
+	// Lookup the offset to the specified row. These offsets start after the
+	// 8-byte page header, as sequence of 2-byte offsets per row.
+	pageOffset := binary.BigEndian.Uint16(page[8+(row*2):])
+
+	// https://sqlite.org/fileformat.html#cellformat
+	payload := page[pageOffset:]
+	pos := 0
+	// Advanced past the first two varints of the payload: payloadSize, rowID
+	for i := 0; i < 2; i++ {
+		_, bytes := binary.Uvarint(payload[pos:])
+		pos += bytes
+	}
+	// Record format: https://sqlite.org/fileformat.html#record_format
+	header := bytes.NewReader(payload[pos:])
+	// The header consists of an initial (varint) header size, followed
+	// by varint sizes of each column value in cid order.
+	recordHeaderLen, err := binary.ReadUvarint(header)
+	if err != nil {
+		return "", err
+	}
+	// pos points to column values (directly after the header)
+	pos += int(recordHeaderLen)
+	for i := 0; ; i++ {
+		serialType, err := binary.ReadUvarint(header)
+		if err != nil {
+			return "", nil
+		}
+		valueLen := lengthOf(serialType)
+		if i == pagePos.CID() {
+			return string(payload[pos : pos+valueLen]), nil
+		}
+		pos += valueLen
+	}
+}
+
+// https://sqlite.org/fileformat.html#serialtype
+func lengthOf(serialType uint64) int {
+	serial := int(serialType)
+	switch serial {
+	case 1, 2, 3, 4:
+		return serial
+	case 5:
+		return 6
+	case 6, 7:
+		return 8
+	case 0, 8, 9, 10, 11, 12, 13:
+		return 0
+	}
+	// BLOB
+	if serial%2 == 0 {
+		return (serial - 12) / 2
+	}
+	// TEXT
+	return (serial - 13) / 2
+}

--- a/lite/page.go
+++ b/lite/page.go
@@ -11,23 +11,23 @@ import (
 // The position of a value within a page.
 type PagePos interface {
 	Row() int
-	CID() int
+	Col() int
 }
 
 // The position of a value within the database.
 type DBPos struct {
 	page uint32
 	row  int
-	cid  int
+	col  int
 }
 
-func NewDBPos(page uint32, row int, cid int) *DBPos {
-	return &DBPos{page: page, row: row, cid: cid}
+func NewDBPos(page uint32, row int, col int) *DBPos {
+	return &DBPos{page: page, row: row, col: col}
 }
 
 func (pos *DBPos) Page() uint32 { return pos.page }
 func (pos *DBPos) Row() int     { return pos.row }
-func (pos *DBPos) CID() int     { return pos.cid }
+func (pos *DBPos) Col() int     { return pos.col }
 
 // Gets the position of the value specified by the given `table`, `column`
 // and `row` (in ROWID order). This assumes that the table fits within a
@@ -36,15 +36,22 @@ func (pos *DBPos) CID() int     { return pos.cid }
 func GetDBPos(db *sql.DB, table string, column string, row int) (*DBPos, error) {
 	var pageNo uint32
 	var cid int
-	if err := db.QueryRow(`SELECT cid FROM pragma_table_info(?) where name = ?`, table, column).
+	var numVirtual int
+	if err := db.QueryRow(`SELECT cid FROM pragma_table_xinfo(?) where name = ?`, table, column).
 		Scan(&cid); err != nil {
 		return nil, fmt.Errorf(`lookup db pos ("%s"."%s") cid: %w`, table, column, err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_xinfo(?) where cid < ? and hidden = 2`, table, cid).
+		Scan(&numVirtual); err != nil {
+		return nil, fmt.Errorf(`lookup db pos ("%s"."%s") numVirtual: %w`, table, column, err)
 	}
 	if err := db.QueryRow(`SELECT rootpage FROM sqlite_schema WHERE name = ?`, table).
 		Scan(&pageNo); err != nil {
 		return nil, fmt.Errorf("lookup %s rootpage: %w", table, err)
 	}
-	return NewDBPos(pageNo, row, cid), nil
+	// Subtract the number of `GENERATED ... VIRTUAL` columns from the cid to
+	// get the position of the value in the page.
+	return NewDBPos(pageNo, row, cid-numVirtual), nil
 }
 
 // Reads the page for the given `pageNo` from the main db file.
@@ -82,7 +89,7 @@ func ReadTextValueFromLeafPage(page []byte, pagePos PagePos) (string, error) {
 	// Record format: https://sqlite.org/fileformat.html#record_format
 	header := bytes.NewReader(payload[pos:])
 	// The header consists of an initial (varint) header size, followed
-	// by varint sizes of each column value in cid order.
+	// by varint sizes of each stored column value.
 	recordHeaderLen, err := binary.ReadUvarint(header)
 	if err != nil {
 		return "", err
@@ -95,7 +102,7 @@ func ReadTextValueFromLeafPage(page []byte, pagePos PagePos) (string, error) {
 			return "", nil
 		}
 		valueLen := lengthOf(serialType)
-		if i == pagePos.CID() {
+		if i == pagePos.Col() {
 			return string(payload[pos : pos+valueLen]), nil
 		}
 		pos += valueLen

--- a/lite/page_test.go
+++ b/lite/page_test.go
@@ -1,0 +1,114 @@
+package lite_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/benbjohnson/litestream/lite"
+	"github.com/mattn/go-sqlite3"
+)
+
+func init() {
+	sql.Register("litestream-sqlite3", &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			if err := conn.SetFileControlInt("main", sqlite3.SQLITE_FCNTL_PERSIST_WAL, 1); err != nil {
+				return fmt.Errorf("cannot set file control: %w", err)
+			}
+			return nil
+		},
+	})
+}
+
+// MustOpenSQLDB returns a database/sql DB and the path to the underlying file.
+func MustOpenSQLDB(tb testing.TB) (*sql.DB, string) {
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), "db")
+	d, err := sql.Open("sqlite3", path)
+	if err != nil {
+		tb.Fatal(err)
+	} else if _, err := d.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		tb.Fatal(err)
+	}
+	return d, path
+}
+
+// MustCloseSQLDB closes a database/sql DB.
+func MustCloseSQLDB(tb testing.TB, d *sql.DB) {
+	tb.Helper()
+	if err := d.Close(); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func TestReplica_ReadTextValueFromLeafPage(t *testing.T) {
+	sqldb, path := MustOpenSQLDB(t)
+	defer MustCloseSQLDB(t, sqldb)
+
+	if _, err := sqldb.Exec(`CREATE TABLE foo(a TEXT, b INT, c TEXT, d FLOAT, e TEXT, f TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO foo(a, b, c, d, e, f) VALUES (
+	 'abc123', 293482039, 'zzzxyzcba', 19382.383828937238, NULL, 'hello, world'
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO foo(a, b, c, d, e, f) VALUES (
+		'boomboom', 300, 'bonk', 1, 130, 'zip'
+	 )`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO foo(a, b, c, d, e, f) VALUES (
+		0, 200, 16000, 120800, 82938298, 'after different int sizes'
+	 )`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA wal_checkpoint(FULL)`); err != nil {
+		t.Fatal(err)
+	}
+	var pageNo uint32
+	var pageSize int
+	if err := sqldb.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqldb.QueryRow(`SELECT rootpage FROM sqlite_schema WHERE name = 'foo'`).Scan(&pageNo); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := lite.ReadPage(file, pageNo, pageSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tests = []struct {
+		row       int
+		cid       int
+		watermark string
+	}{
+		{row: 0, cid: 0, watermark: "abc123"},
+		{row: 0, cid: 2, watermark: "zzzxyzcba"},
+		{row: 0, cid: 4, watermark: ""},
+		{row: 0, cid: 5, watermark: "hello, world"},
+		{row: 1, cid: 0, watermark: "boomboom"},
+		{row: 1, cid: 2, watermark: "bonk"},
+		{row: 1, cid: 4, watermark: "130"},
+		{row: 1, cid: 5, watermark: "zip"},
+		{row: 2, cid: 0, watermark: "0"},
+		{row: 2, cid: 2, watermark: "16000"},
+		{row: 2, cid: 4, watermark: "82938298"},
+		{row: 2, cid: 5, watermark: "after different int sizes"},
+	}
+	for _, test := range tests {
+		pos := lite.NewDBPos(pageNo, test.row, test.cid)
+		if watermark, err := lite.ReadTextValueFromLeafPage(page, pos); err != nil {
+			t.Fatal(err)
+		} else if watermark != test.watermark {
+			t.Fatalf("cid=%d, expected: %s, got: %s", test.cid, test.watermark, watermark)
+		}
+	}
+}

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -44,7 +44,7 @@ func (c *ReplicaClient) DeleteSnapshot(ctx context.Context, generation string, i
 	return c.DeleteSnapshotFunc(ctx, generation, index)
 }
 
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	return c.SnapshotReaderFunc(ctx, generation, index)
 }
 

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -36,7 +36,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 	return c.SnapshotsFunc(ctx, generation)
 }
 
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader) (litestream.SnapshotInfo, error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader, uncompressedSize int64) (litestream.SnapshotInfo, error) {
 	return c.WriteSnapshotFunc(ctx, generation, index, r)
 }
 
@@ -52,7 +52,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 	return c.WALSegmentsFunc(ctx, generation)
 }
 
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, r io.Reader) (litestream.WALSegmentInfo, error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, r io.Reader, uncompressedSize int64) (litestream.WALSegmentInfo, error) {
 	return c.WriteWALSegmentFunc(ctx, pos, r)
 }
 

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -44,7 +44,7 @@ func (c *ReplicaClient) DeleteSnapshot(ctx context.Context, generation string, i
 	return c.DeleteSnapshotFunc(ctx, generation, index)
 }
 
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
 	return c.SnapshotReaderFunc(ctx, generation, index)
 }
 

--- a/replica.go
+++ b/replica.go
@@ -1111,10 +1111,14 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Initialize starting position.
 	pos := Pos{Generation: opt.Generation, Index: minWALIndex}
 	tmpPath := opt.OutputPath + ".tmp"
+	readerOpts := &ReaderOptions{
+		MultipartConcurrency: opt.MultipartConcurrency,
+		MultipartSize:        opt.MultipartSize,
+	}
 
 	// Copy snapshot to output path.
 	r.Logger().Info("restoring snapshot", "generation", opt.Generation, "index", minWALIndex, "path", tmpPath)
-	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath); err != nil {
+	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath, readerOpts); err != nil {
 		return fmt.Errorf("cannot restore snapshot: %w", err)
 	}
 
@@ -1335,7 +1339,7 @@ func (r *Replica) walSegmentMap(ctx context.Context, generation string, minIndex
 }
 
 // restoreSnapshot copies a snapshot from the replica to a file.
-func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string) error {
+func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string, opt *ReaderOptions) error {
 	// Determine the user/group & mode based on the DB, if available.
 	var fileInfo, dirInfo os.FileInfo
 	if db := r.DB(); db != nil {
@@ -1352,7 +1356,7 @@ func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index 
 	}
 	defer f.Close()
 
-	rd, err := r.Client.SnapshotReader(ctx, generation, index)
+	rd, err := r.Client.SnapshotReader(ctx, generation, index, opt)
 	if err != nil {
 		return err
 	}

--- a/replica.go
+++ b/replica.go
@@ -1115,14 +1115,10 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Initialize starting position.
 	pos := Pos{Generation: opt.Generation, Index: minWALIndex}
 	tmpPath := opt.OutputPath + ".tmp"
-	readerOpts := &ReaderOptions{
-		MultipartConcurrency: opt.MultipartConcurrency,
-		MultipartSize:        opt.MultipartSize,
-	}
 
 	// Copy snapshot to output path.
 	r.Logger().Info("restoring snapshot", "generation", opt.Generation, "index", minWALIndex, "path", tmpPath)
-	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath, readerOpts); err != nil {
+	if err := r.restoreSnapshot(ctx, pos.Generation, pos.Index, tmpPath); err != nil {
 		return fmt.Errorf("cannot restore snapshot: %w", err)
 	}
 
@@ -1343,7 +1339,7 @@ func (r *Replica) walSegmentMap(ctx context.Context, generation string, minIndex
 }
 
 // restoreSnapshot copies a snapshot from the replica to a file.
-func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string, opt *ReaderOptions) error {
+func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index int, filename string) error {
 	// Determine the user/group & mode based on the DB, if available.
 	var fileInfo, dirInfo os.FileInfo
 	if db := r.DB(); db != nil {
@@ -1360,7 +1356,7 @@ func (r *Replica) restoreSnapshot(ctx context.Context, generation string, index 
 	}
 	defer f.Close()
 
-	rd, err := r.Client.SnapshotReader(ctx, generation, index, opt)
+	rd, err := r.Client.SnapshotReader(ctx, generation, index)
 	if err != nil {
 		return err
 	}

--- a/replica.go
+++ b/replica.go
@@ -1176,6 +1176,17 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 
 	// Download WAL files to disk in parallel.
 	g, ctx := errgroup.WithContext(ctx)
+	// An error in one of the go routines spawned by the group will result in canceling
+	// the context, hiding the underlying error in an unhelpful "context canceled" error.
+	// Log both the error and the underlying cause, returning the latter if present.
+	logAndUnwrap := func(err error) error {
+		cause := context.Cause(ctx)
+		r.Logger().Error("error downloading wal", "error", err, "cause", cause)
+		if cause != nil {
+			return cause
+		}
+		return err
+	}
 	for i := 0; i < parallelism; i++ {
 		g.Go(func() error {
 			for {
@@ -1204,7 +1215,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 
 					// Returning the error here will cancel the other goroutines.
 					if err != nil {
-						return err
+						return logAndUnwrap(err)
 					}
 
 					r.Logger().Info("downloaded wal",
@@ -1222,7 +1233,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 		mu.Lock()
 		for !walStates[index-minWALIndex].ready {
 			if err := ctx.Err(); err != nil {
-				return err
+				return logAndUnwrap(err)
 			}
 			cond.Wait()
 		}
@@ -1242,7 +1253,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Ensure all goroutines finish. All errors should have been handled during
 	// the processing of WAL files but this ensures that all processing is done.
 	if err := g.Wait(); err != nil {
-		return err
+		return logAndUnwrap(err)
 	}
 
 	// Copy file to final location.

--- a/replica_client.go
+++ b/replica_client.go
@@ -5,6 +5,11 @@ import (
 	"io"
 )
 
+type ReaderOptions struct {
+	MultipartConcurrency int
+	MultipartSize        int64
+}
+
 // ReplicaClient represents client to connect to a Replica.
 type ReplicaClient interface {
 	// Returns the type of client.
@@ -29,7 +34,9 @@ type ReplicaClient interface {
 	// Returns a reader that contains LZ4 compressed snapshot data for a
 	// given index within a generation. Returns an os.ErrNotFound error if
 	// the snapshot does not exist.
-	SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error)
+	//
+	// The ReaderOptions may be nil or ignored by the implementation.
+	SnapshotReader(ctx context.Context, generation string, index int, opt *ReaderOptions) (io.ReadCloser, error)
 
 	// Returns an iterator of all WAL segments within a generation on the replica. Order is undefined.
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)

--- a/replica_client.go
+++ b/replica_client.go
@@ -25,8 +25,11 @@ type ReplicaClient interface {
 	Snapshots(ctx context.Context, generation string) (SnapshotIterator, error)
 
 	// Writes LZ4 compressed snapshot data to the replica at a given index
-	// within a generation. Returns metadata for the snapshot.
-	WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader) (SnapshotInfo, error)
+	// within a generation. The uncompressedSize is supplied to allow
+	// implementations to perform appropriate optimizations.
+	//
+	// Returns metadata for the snapshot.
+	WriteSnapshot(ctx context.Context, generation string, index int, r io.Reader, uncompressedSize int64) (SnapshotInfo, error)
 
 	// Deletes a snapshot with the given generation & index.
 	DeleteSnapshot(ctx context.Context, generation string, index int) error
@@ -42,8 +45,11 @@ type ReplicaClient interface {
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)
 
 	// Writes an LZ4 compressed WAL segment at a given position.
+	// The uncompressedSize is supplied to allow implementations to perform
+	// appropriate optimizations.
+	//
 	// Returns metadata for the written segment.
-	WriteWALSegment(ctx context.Context, pos Pos, r io.Reader) (WALSegmentInfo, error)
+	WriteWALSegment(ctx context.Context, pos Pos, r io.Reader, uncompressedSize int64) (WALSegmentInfo, error)
 
 	// Deletes one or more WAL segments at the given positions.
 	DeleteWALSegments(ctx context.Context, a []Pos) error

--- a/replica_client.go
+++ b/replica_client.go
@@ -5,11 +5,6 @@ import (
 	"io"
 )
 
-type ReaderOptions struct {
-	MultipartConcurrency int
-	MultipartSize        int64
-}
-
 // ReplicaClient represents client to connect to a Replica.
 type ReplicaClient interface {
 	// Returns the type of client.
@@ -39,7 +34,7 @@ type ReplicaClient interface {
 	// the snapshot does not exist.
 	//
 	// The ReaderOptions may be nil or ignored by the implementation.
-	SnapshotReader(ctx context.Context, generation string, index int, opt *ReaderOptions) (io.ReadCloser, error)
+	SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error)
 
 	// Returns an iterator of all WAL segments within a generation on the replica. Order is undefined.
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -190,7 +190,7 @@ func TestReplicaClient_WriteSnapshot(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if r, err := c.SnapshotReader(context.Background(), "b16ddcf5c697540f", 1000); err != nil {
+		if r, err := c.SnapshotReader(context.Background(), "b16ddcf5c697540f", 1000, nil); err != nil {
 			t.Fatal(err)
 		} else if buf, err := io.ReadAll(r); err != nil {
 			t.Fatal(err)
@@ -217,7 +217,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 10)
+		r, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 10, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -230,10 +230,34 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 		}
 	})
 
+	RunWithReplicaClient(t, "Multipart", func(t *testing.T, c litestream.ReplicaClient) {
+		t.Parallel()
+
+		content := strings.Repeat(`abc123`, 10000)
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(content)); err != nil {
+			t.Fatal(err)
+		}
+
+		r, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 10, &litestream.ReaderOptions{
+			MultipartConcurrency: 13,
+			MultipartSize:        123,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+
+		if buf, err := io.ReadAll(r); err != nil {
+			t.Fatal(err)
+		} else if got, want := string(buf), content; got != want {
+			t.Fatalf("ReadAll=%v, want %v", got, want)
+		}
+	})
+
 	RunWithReplicaClient(t, "ErrNotFound", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 1); !os.IsNotExist(err) {
+		if _, err := c.SnapshotReader(context.Background(), "5efbd8d042012dca", 1, nil); !os.IsNotExist(err) {
 			t.Fatalf("expected not exist, got %#v", err)
 		}
 	})
@@ -241,7 +265,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 	RunWithReplicaClient(t, "ErrNoGeneration", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.SnapshotReader(context.Background(), "", 1); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
+		if _, err := c.SnapshotReader(context.Background(), "", 1, nil); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -67,11 +67,11 @@ func TestReplicaClient_Generations(t *testing.T) {
 		t.Parallel()
 
 		// Write snapshots.
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 0, strings.NewReader(`bar`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 0, strings.NewReader(`bar`), 3); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "155fe292f8333c72", 0, strings.NewReader(`baz`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "155fe292f8333c72", 0, strings.NewReader(`baz`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -103,11 +103,11 @@ func TestReplicaClient_Snapshots(t *testing.T) {
 		t.Parallel()
 
 		// Write snapshots.
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 1, strings.NewReader(``)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 1, strings.NewReader(``), 0); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 5, strings.NewReader(`x`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 5, strings.NewReader(`x`), 1); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 10, strings.NewReader(`xyz`)); err != nil {
+		} else if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 10, strings.NewReader(`xyz`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -186,7 +186,7 @@ func TestReplicaClient_WriteSnapshot(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 1000, strings.NewReader(`foobar`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "b16ddcf5c697540f", 1000, strings.NewReader(`foobar`), 6); err != nil {
 			t.Fatal(err)
 		}
 
@@ -203,7 +203,7 @@ func TestReplicaClient_WriteSnapshot(t *testing.T) {
 
 	RunWithReplicaClient(t, "ErrNoGeneration", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
-		if _, err := c.WriteSnapshot(context.Background(), "", 0, nil); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
+		if _, err := c.WriteSnapshot(context.Background(), "", 0, nil, 0); err == nil || err.Error() != `cannot determine snapshot path: generation required` {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -213,7 +213,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -234,7 +234,7 @@ func TestReplicaClient_SnapshotReader(t *testing.T) {
 		t.Parallel()
 
 		content := strings.Repeat(`abc123`, 10000)
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(content)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 10, strings.NewReader(content), int64(len(content))); err != nil {
 			t.Fatal(err)
 		}
 
@@ -275,14 +275,14 @@ func TestReplicaClient_WALs(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 1, Offset: 0}, strings.NewReader(``)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 1, Offset: 0}, strings.NewReader(``), 0); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 0}, strings.NewReader(`12345`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 0}, strings.NewReader(`12345`), 5); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 5}, strings.NewReader(`67`)); err != nil {
+		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 2, Offset: 5}, strings.NewReader(`67`), 2); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 3, Offset: 0}, strings.NewReader(`xyz`)); err != nil {
+		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 3, Offset: 0}, strings.NewReader(`xyz`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -363,7 +363,7 @@ func TestReplicaClient_WALs(t *testing.T) {
 	RunWithReplicaClient(t, "NoWALs", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteSnapshot(context.Background(), "5efbd8d042012dca", 0, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
 		}
 
@@ -395,7 +395,7 @@ func TestReplicaClient_WriteWALSegment(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1000, Offset: 2000}, strings.NewReader(`foobar`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1000, Offset: 2000}, strings.NewReader(`foobar`), 6); err != nil {
 			t.Fatal(err)
 		}
 
@@ -412,7 +412,7 @@ func TestReplicaClient_WriteWALSegment(t *testing.T) {
 
 	RunWithReplicaClient(t, "ErrNoGeneration", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "", Index: 0, Offset: 0}, nil); err == nil || err.Error() != `cannot determine wal segment path: generation required` {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "", Index: 0, Offset: 0}, nil, 0); err == nil || err.Error() != `cannot determine wal segment path: generation required` {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -422,7 +422,7 @@ func TestReplicaClient_WALReader(t *testing.T) {
 
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 10, Offset: 5}, strings.NewReader(`foobar`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 10, Offset: 5}, strings.NewReader(`foobar`), 6); err != nil {
 			t.Fatal(err)
 		}
 
@@ -452,9 +452,9 @@ func TestReplicaClient_DeleteWALSegments(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1, Offset: 2}, strings.NewReader(`foo`)); err != nil {
+		if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "b16ddcf5c697540f", Index: 1, Offset: 2}, strings.NewReader(`foo`), 3); err != nil {
 			t.Fatal(err)
-		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 3, Offset: 4}, strings.NewReader(`bar`)); err != nil {
+		} else if _, err := c.WriteWALSegment(context.Background(), litestream.Pos{Generation: "5efbd8d042012dca", Index: 3, Offset: 4}, strings.NewReader(`bar`), 3); err != nil {
 			t.Fatal(err)
 		}
 

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -510,8 +510,10 @@ func NewS3ReplicaClient(tb testing.TB) *s3.ReplicaClient {
 	c.Endpoint = *s3Endpoint
 	c.ForcePathStyle = *s3ForcePathStyle
 	c.SkipVerify = *s3SkipVerify
-	c.MultipartConcurrency = 5
-	c.MultipartSize = 100
+	multipartConcurrency := 5
+	multipartSize := int64(100)
+	c.MultipartConcurrency = &multipartConcurrency
+	c.MultipartSize = &multipartSize
 	return c
 }
 

--- a/s3/multi_part.go
+++ b/s3/multi_part.go
@@ -1,0 +1,189 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/benbjohnson/litestream/internal"
+)
+
+func Download(ctx context.Context, sd *s3manager.Downloader, input *s3.GetObjectInput) io.ReadCloser {
+	r, w := io.Pipe()
+	m := NewPartManager(w, sd.PartSize, sd.Concurrency)
+
+	go m.PipeCompletedParts()
+
+	go func() {
+		if _, err := sd.DownloadWithContext(ctx, m, input); err != nil {
+			if isNotExists(err) {
+				err = os.ErrNotExist
+			}
+			m.w.CloseWithError(err)
+		} else {
+			m.DownloadDone()
+		}
+	}()
+
+	return r
+}
+
+type part struct {
+	start   int64
+	written int64
+	buf     *bytes.Buffer
+}
+
+// The partManager manages the multi-part download done by the s3.Downloader,
+// implementing the WriterAt interface by collecting data from downloading
+// parts in a fixed number of Buffers, and piping them to the PipeWriter in
+// the correct order.
+//
+// The manager manages max `concurrency` parts of `partSize` bytes. The parts
+// begin in the `available` pool with assigned starting positions, moving to
+// the `downloading` pool when data for the part is received by the Downloader.
+// When fully written, the parts are transferred to the `done` pool from which
+// they are piped, in order, to the PipeWriter and returned `available` pool to
+// be used for the next part in line.
+type partManager struct {
+	w        *io.PipeWriter
+	partSize int64
+
+	freed      *sync.Cond      // conditionalized/signaled access to available
+	nextInLine int64           // tracks the next position allowed to receive data
+	available  map[int64]*part // parts available to receive data
+
+	downloading sync.Map   // parts receiving data
+	full        chan *part // transfers full parts from downloading to done
+
+	done      sync.Map // parts ready to be flushed
+	flushHead int64    // tracks the next position to be flushed
+}
+
+// Exposed for testing
+func NewPartManager(w *io.PipeWriter, partSize int64, concurrency int) *partManager {
+	m := &partManager{
+		w:         w,
+		partSize:  partSize,
+		freed:     sync.NewCond(&sync.Mutex{}),
+		available: make(map[int64]*part),
+		full:      make(chan *part, concurrency),
+	}
+	for i := 0; i < concurrency; i++ {
+		m.setFree(&part{})
+	}
+	return m
+}
+
+// A naive, first-come-first-serve free pool would be subject to head-of-line
+// blocking. For example, in a pathological case, if the first part is slow to
+// start receiving data, a subsequent part may complete its download and start
+// receiving data for its next part, occupying all `n` buffers before the first
+// part has a chance to reserve a buffer, thereby preventing the entire
+// download from progressing (since parts have to be piped in order).
+//
+// To avoid this, free parts are explicitly reserved for the next parts in
+// line, ensuring that the head of the line will always be able to receive a
+// buffer and keep the pipe flowing.
+func (m *partManager) setFree(p *part) {
+	m.freed.L.Lock()
+	defer m.freed.L.Unlock()
+
+	m.available[m.nextInLine] = p
+	m.nextInLine += m.partSize
+	m.freed.Broadcast()
+}
+
+func (m *partManager) getFree(chunkStart int64) *part {
+	m.freed.L.Lock()
+	defer m.freed.L.Unlock()
+	for {
+		if p, exists := m.available[chunkStart]; exists {
+			delete(m.available, chunkStart)
+			return p
+		}
+		m.freed.Wait()
+	}
+}
+
+// WriteAt is the interface called to receive data for chunks being downloaded
+// by the s3.Downloader.
+func (m *partManager) WriteAt(p []byte, pos int64) (n int, err error) {
+	part := m.getDownloading(pos)
+	n, err = part.buf.Write(p)
+	if err == nil {
+		part.written += int64(n)
+		if part.written >= m.partSize {
+			m.full <- part
+		}
+	}
+	return
+}
+
+func (m *partManager) getDownloading(pos int64) *part {
+	start := pos - (pos % m.partSize)
+	if p, exists := m.downloading.Load(start); exists {
+		return p.(*part)
+	}
+
+	part := m.getFree(start)
+	part.start = start
+	part.written = 0
+
+	if part.buf == nil {
+		// Pre-allocate space for the part, both for speed and to avoid
+		// over-allocating with on-demand Buffer growth.
+		part.buf = new(bytes.Buffer)
+		part.buf.Grow(int(m.partSize))
+	} else {
+		part.buf.Reset()
+	}
+
+	m.downloading.Store(start, part)
+	return part
+}
+
+// Exposed for testing
+func (m *partManager) PipeCompletedParts() {
+	for part := range m.full {
+		// Move the part from downloading to done
+		m.downloading.Delete(part.start)
+		m.done.Store(part.start, part)
+
+		// Flush the head of the line
+		m.flush(&m.done)
+	}
+
+	// Once m.full is closed, there are no more writers.
+	// The final part at the flushHead will be in m.downloading
+	// if it did not reach the full partSize.
+	m.flush(&m.downloading)
+	m.w.Close()
+}
+
+// Exposed for testing
+func (m *partManager) DownloadDone() {
+	close(m.full)
+}
+
+func (m *partManager) flush(parts *sync.Map) {
+	for p, exists := parts.Load(m.flushHead); exists; p, exists = parts.Load(m.flushHead) {
+		p := p.(*part)
+		io.Copy(m.w, p.buf)
+
+		num := p.written
+		m.setFree(p)
+
+		parts.Delete(m.flushHead)
+		m.flushHead += m.partSize
+
+		// Each part corresponds to an underlying GET in the s3 client.
+		internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "GET").Inc()
+		internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "GET").Add(float64(aws.Int64Value(&num)))
+	}
+}

--- a/s3/multi_part.go
+++ b/s3/multi_part.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"os"
@@ -34,9 +33,9 @@ func Download(ctx context.Context, sd *s3manager.Downloader, input *s3.GetObject
 }
 
 type part struct {
-	start   int64
-	written int64
-	buf     *bytes.Buffer
+	start      int64
+	maxWritten int64
+	buf        []byte
 }
 
 // The partManager manages the multi-part download done by the s3.Downloader,
@@ -115,14 +114,25 @@ func (m *partManager) getFree(chunkStart int64) *part {
 // by the s3.Downloader.
 func (m *partManager) WriteAt(p []byte, pos int64) (n int, err error) {
 	part := m.getDownloading(pos)
-	n, err = part.buf.Write(p)
-	if err == nil {
-		part.written += int64(n)
-		if part.written >= m.partSize {
+	off := pos - part.start
+	end := off + int64(len(p))
+	if off < 0 || end > int64(len(part.buf)) {
+		return 0, io.ErrShortWrite
+	}
+
+	n = copy(part.buf[int(off):int(end)], p)
+	if n != len(p) {
+		return n, io.ErrShortWrite
+	}
+
+	if end > part.maxWritten {
+		part.maxWritten = end
+		if part.maxWritten >= m.partSize {
 			m.full <- part
 		}
 	}
-	return
+
+	return n, nil
 }
 
 func (m *partManager) getDownloading(pos int64) *part {
@@ -133,15 +143,10 @@ func (m *partManager) getDownloading(pos int64) *part {
 
 	part := m.getFree(start)
 	part.start = start
-	part.written = 0
+	part.maxWritten = 0
 
 	if part.buf == nil {
-		// Pre-allocate space for the part, both for speed and to avoid
-		// over-allocating with on-demand Buffer growth.
-		part.buf = new(bytes.Buffer)
-		part.buf.Grow(int(m.partSize))
-	} else {
-		part.buf.Reset()
+		part.buf = make([]byte, int(m.partSize))
 	}
 
 	m.downloading.Store(start, part)
@@ -174,9 +179,9 @@ func (m *partManager) DownloadDone() {
 func (m *partManager) flush(parts *sync.Map) {
 	for p, exists := parts.Load(m.flushHead); exists; p, exists = parts.Load(m.flushHead) {
 		p := p.(*part)
-		io.Copy(m.w, p.buf)
+		m.w.Write(p.buf[:int(p.maxWritten)])
 
-		num := p.written
+		num := p.maxWritten
 		m.setFree(p)
 
 		parts.Delete(m.flushHead)

--- a/s3/multi_part_test.go
+++ b/s3/multi_part_test.go
@@ -1,0 +1,70 @@
+package s3_test
+
+import (
+	"bytes"
+	crypto "crypto/rand"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/benbjohnson/litestream/s3"
+)
+
+func TestMultiPartDownload(t *testing.T) {
+	const numBytes = 1234 * 1023 // Non-round size to ensure a partial part at the end
+	const partSize = 1000
+
+	for _, c := range []int{1, 2, 23} {
+		t.Run(fmt.Sprintf("concurrency=%d", c), func(t *testing.T) {
+			testMultiPartDownload(t, numBytes, partSize, c)
+		})
+	}
+}
+
+func testMultiPartDownload(t *testing.T, numBytes int64, partSize int64, concurrency int) {
+	randomBytes := make([]byte, numBytes)
+	if _, err := crypto.Read(randomBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	r, w := io.Pipe()
+	m := s3.NewPartManager(w, partSize, concurrency)
+	go m.PipeCompletedParts()
+
+	var head atomic.Int64
+	nextHead := func() int64 {
+		return head.Add(partSize) - partSize
+	}
+
+	// Simulates the s3.Downloader by running `concurrency` routines that
+	// take `partSize`` slices of the randomBytes from the head and call
+	// m.WriteAt() to randomly send the slices to the part manager.
+	var requests sync.WaitGroup
+	requests.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			for start := nextHead(); start < numBytes; start = nextHead() {
+				for end := min(numBytes, start+partSize); start < end; {
+					len := rand.Int63n(end-start) + 1
+					m.WriteAt(randomBytes[start:start+len], start)
+					start += len
+				}
+			}
+			requests.Done()
+		}()
+	}
+
+	go func() {
+		requests.Wait()
+		m.DownloadDone()
+	}()
+
+	if result, err := io.ReadAll(r); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(randomBytes, result) {
+		t.Fatalf("downloaded bytes not equal")
+	}
+}

--- a/s3/multi_part_test.go
+++ b/s3/multi_part_test.go
@@ -68,3 +68,42 @@ func testMultiPartDownload(t *testing.T, numBytes int64, partSize int64, concurr
 		t.Fatalf("downloaded bytes not equal")
 	}
 }
+
+func TestMultiPartDownloadRetryRewritesPart(t *testing.T) {
+	const partSize int64 = 8
+	payload := []byte("abcdefghijklmnop")
+
+	r, w := io.Pipe()
+	m := s3.NewPartManager(w, partSize, 1)
+	go m.PipeCompletedParts()
+
+	type readResult struct {
+		buf []byte
+		err error
+	}
+	resultCh := make(chan readResult, 1)
+	go func() {
+		buf, err := io.ReadAll(r)
+		resultCh <- readResult{buf: buf, err: err}
+	}()
+
+	if _, err := m.WriteAt(payload[:3], 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.WriteAt(payload[:int(partSize)], 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.WriteAt(payload[int(partSize):], partSize); err != nil {
+		t.Fatal(err)
+	}
+
+	m.DownloadDone()
+
+	result := <-resultCh
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if !bytes.Equal(payload, result.buf) {
+		t.Fatalf("unexpected payload: %q", result.buf)
+	}
+}

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -140,12 +140,12 @@ func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (st
 
 	// Fetch bucket location, if possible. Must be bucket owner.
 	// This call can return a nil location which means it's in us-east-1.
-	if out, err := s3.New(sess).HeadBucketWithContext(ctx, &s3.HeadBucketInput{
+	if out, err := s3.New(sess).GetBucketLocation(&s3.GetBucketLocationInput{
 		Bucket: aws.String(bucket),
 	}); err != nil {
 		return "", err
-	} else if out.BucketRegion != nil {
-		return *out.BucketRegion, nil
+	} else if out.LocationConstraint != nil {
+		return *out.LocationConstraint, nil
 	}
 	return DefaultRegion, nil
 }

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -53,9 +53,9 @@ type ReplicaClient struct {
 	ForcePathStyle bool
 	SkipVerify     bool
 
-	// S3 object download options
-	MultipartDownloadConcurrency int
-	MultipartDownloadSize        int
+	// S3 object multipart options
+	MultipartConcurrency *int
+	MultipartSize        *int64
 }
 
 // NewReplicaClient returns a new instance of ReplicaClient.
@@ -244,6 +244,13 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 // to the multipart download API.
 func (c *ReplicaClient) newUploader(uncompressedSize int64) *s3manager.Uploader {
 	return s3manager.NewUploaderWithClient(c.s3, func(d *s3manager.Uploader) {
+		if c.MultipartConcurrency != nil {
+			d.Concurrency = *c.MultipartConcurrency
+		}
+		if c.MultipartSize != nil {
+			d.PartSize = *c.MultipartSize
+		}
+
 		// The Uploader attempts to perform an initSize() optimization to configure the
 		// upload part size based on the total upload size. However, this is only possible
 		// if the io.Reader that it is given implements io.Seeker:
@@ -283,7 +290,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 
 	rc := internal.NewReadCounter(rd)
 	uploader := c.newUploader(uncompressedSize)
-	slog.Debug(fmt.Sprintf("uploading snapshot with part size %d", uploader.PartSize))
+	slog.Debug(fmt.Sprintf("uploading snapshot in %d parallel parts of size %d", uploader.Concurrency, uploader.PartSize))
 	if _, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		Bucket: aws.String(c.Bucket),
 		Key:    aws.String(key),
@@ -306,7 +313,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (io.ReadCloser, error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}
@@ -321,24 +328,30 @@ func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, i
 		Key:    aws.String(key),
 	}
 
-	if opt != nil && opt.MultipartConcurrency > 0 && opt.MultipartSize > 0 {
-		downloader := s3manager.NewDownloaderWithClient(c.s3, func(d *s3manager.Downloader) {
-			d.Concurrency = opt.MultipartConcurrency
-			d.PartSize = opt.MultipartSize
-		})
-		return Download(ctx, downloader, input), nil
+	if c.MultipartConcurrency != nil && *c.MultipartConcurrency == 0 {
+		// Multipart downloads are explicitly disabled by setting concurrency to 0.
+		out, err := c.s3.GetObjectWithContext(ctx, input)
+		if isNotExists(err) {
+			return nil, os.ErrNotExist
+		} else if err != nil {
+			return nil, err
+		}
+		internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "GET").Inc()
+		internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "GET").Add(float64(aws.Int64Value(out.ContentLength)))
+
+		return out.Body, nil
 	}
 
-	out, err := c.s3.GetObjectWithContext(ctx, input)
-	if isNotExists(err) {
-		return nil, os.ErrNotExist
-	} else if err != nil {
-		return nil, err
-	}
-	internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "GET").Inc()
-	internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "GET").Add(float64(aws.Int64Value(out.ContentLength)))
-
-	return out.Body, nil
+	downloader := s3manager.NewDownloaderWithClient(c.s3, func(d *s3manager.Downloader) {
+		if c.MultipartConcurrency != nil {
+			d.Concurrency = *c.MultipartConcurrency
+		}
+		if c.MultipartSize != nil {
+			d.PartSize = *c.MultipartSize
+		}
+	})
+	slog.Debug(fmt.Sprintf("downloading snapshot in %d parallel parts of size %d", downloader.Concurrency, downloader.PartSize))
+	return Download(ctx, downloader, input), nil
 }
 
 // DeleteSnapshot deletes a snapshot with the given generation & index.

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -275,7 +275,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (_ io.ReadCloser, err error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (_ io.ReadCloser, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -275,7 +275,7 @@ func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, in
 }
 
 // SnapshotReader returns a reader for snapshot data at the given generation/index.
-func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int) (_ io.ReadCloser, err error) {
+func (c *ReplicaClient) SnapshotReader(ctx context.Context, generation string, index int, opt *litestream.ReaderOptions) (_ io.ReadCloser, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -230,7 +230,7 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (_ lit
 }
 
 // WriteSnapshot writes LZ4 compressed data from rd to the object storage.
-func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader) (info litestream.SnapshotInfo, err error) {
+func (c *ReplicaClient) WriteSnapshot(ctx context.Context, generation string, index int, rd io.Reader, uncompressedSize int64) (info litestream.SnapshotInfo, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)
@@ -362,7 +362,7 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (_ l
 }
 
 // WriteWALSegment writes LZ4 compressed data from rd into a file on disk.
-func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader) (info litestream.WALSegmentInfo, err error) {
+func (c *ReplicaClient) WriteWALSegment(ctx context.Context, pos litestream.Pos, rd io.Reader, uncompressedSize int64) (info litestream.WALSegmentInfo, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)


### PR DESCRIPTION
Include the `cmd` attribute in litestream logs (e.g. `restore` vs `replicate`), which can be used to distinguished how error messages from litestream are handled.