### PR TITLE
chore: include a `cmd` attribute in logging output

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -286,6 +286,7 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 
 	logHandler = logHandler.WithAttrs([]slog.Attr{
 		{Key: "worker", Value: slog.StringValue("litestream")},
+		{Key: "cmd", Value: slog.StringValue((os.Args[1]))},
 	})
 
 	// Set global default logger.


### PR DESCRIPTION
Include a `cmd` attribute in litestream logs (e.g. "restore" vs "replicate"), which can be used to distinguished how error messages from litestream are handled.